### PR TITLE
Trim e-mail addresses in the request builders

### DIFF
--- a/src/RequestBuilder/AbstractRequestBuilder.php
+++ b/src/RequestBuilder/AbstractRequestBuilder.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Netresearch\Sdk\CentralStation\RequestBuilder;
 
+use function trim;
+
 /**
  * An abstract request builder providing common methods for all request builders.
  *
@@ -26,4 +28,16 @@ abstract class AbstractRequestBuilder implements RequestBuilderInterface
      * @var array<string, mixed>
      */
     protected array $data = [];
+
+    /**
+     * Normalizes an e-mail address by trimming surrounding whitespace, so the
+     * stored value matches the (also trimmed) lookup key and a whitespace
+     * e-mail never creates a duplicate contact.
+     *
+     * @param string|null $emailAddress
+     */
+    protected function normalizeEmailAddress(?string $emailAddress): ?string
+    {
+        return $emailAddress === null ? null : trim($emailAddress);
+    }
 }

--- a/src/RequestBuilder/Companies/CreateRequestBuilder.php
+++ b/src/RequestBuilder/Companies/CreateRequestBuilder.php
@@ -148,6 +148,8 @@ class CreateRequestBuilder extends AbstractRequestBuilder
      */
     public function addEmailAddress(string $type, string $emailAddress): CreateRequestBuilder
     {
+        $emailAddress = $this->normalizeEmailAddress($emailAddress);
+
         if (!isset($this->data['emailAddresses'])) {
             $this->data['emailAddresses'] = [];
         }

--- a/src/RequestBuilder/Companies/UpdateRequestBuilder.php
+++ b/src/RequestBuilder/Companies/UpdateRequestBuilder.php
@@ -155,6 +155,8 @@ class UpdateRequestBuilder extends AbstractRequestBuilder
         ?string $type = null,
         ?string $emailAddress = null,
     ): UpdateRequestBuilder {
+        $emailAddress = $this->normalizeEmailAddress($emailAddress);
+
         if (!isset($this->data['emailAddresses'])) {
             $this->data['emailAddresses'] = [];
         }

--- a/src/RequestBuilder/People/CreateRequestBuilder.php
+++ b/src/RequestBuilder/People/CreateRequestBuilder.php
@@ -174,6 +174,8 @@ class CreateRequestBuilder extends AbstractRequestBuilder
      */
     public function addEmailAddress(string $type, string $emailAddress): CreateRequestBuilder
     {
+        $emailAddress = $this->normalizeEmailAddress($emailAddress);
+
         if (!isset($this->data['emailAddresses'])) {
             $this->data['emailAddresses'] = [];
         }

--- a/src/RequestBuilder/People/UpdateRequestBuilder.php
+++ b/src/RequestBuilder/People/UpdateRequestBuilder.php
@@ -184,6 +184,8 @@ class UpdateRequestBuilder extends AbstractRequestBuilder
         ?string $type = null,
         ?string $emailAddress = null,
     ): UpdateRequestBuilder {
+        $emailAddress = $this->normalizeEmailAddress($emailAddress);
+
         if (!isset($this->data['emailAddresses'])) {
             $this->data['emailAddresses'] = [];
         }

--- a/test/RequestBuilder/EmailTrimTest.php
+++ b/test/RequestBuilder/EmailTrimTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the package netresearch/sdk-api-central-station.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\Sdk\CentralStation\Test\RequestBuilder;
+
+use JsonException;
+use Netresearch\Sdk\CentralStation\Constants;
+use Netresearch\Sdk\CentralStation\Exception\RequestValidatorException;
+use Netresearch\Sdk\CentralStation\RequestBuilder\Companies\CreateRequestBuilder as CompaniesCreateRequestBuilder;
+use Netresearch\Sdk\CentralStation\RequestBuilder\Companies\UpdateRequestBuilder as CompaniesUpdateRequestBuilder;
+use Netresearch\Sdk\CentralStation\RequestBuilder\People\CreateRequestBuilder as PeopleCreateRequestBuilder;
+use Netresearch\Sdk\CentralStation\RequestBuilder\People\UpdateRequestBuilder as PeopleUpdateRequestBuilder;
+
+/**
+ * Class EmailTrimTest.
+ *
+ * Verifies that every request builder trims the stored e-mail address so it
+ * matches the (also trimmed) lookup key and never creates a duplicate contact.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ * @link    https://www.netresearch.de
+ */
+class EmailTrimTest extends RequestBuilderTestCase
+{
+    /**
+     * @return array<string, array{0: callable(string): object, 1: string}>
+     */
+    public static function builderProvider(): array
+    {
+        return [
+            'people create' => [
+                static fn (string $email): object => (new PeopleCreateRequestBuilder())
+                    ->setPerson('Miller', 'Marian', Constants::GENDER_MALE)
+                    ->addEmailAddress(Constants::CONTACT_DETAILS_TYPE_OFFICE, $email)
+                    ->create(),
+                'person',
+            ],
+            'people update' => [
+                static fn (string $email): object => (new PeopleUpdateRequestBuilder())
+                    ->setPerson('Miller', 'Marian', Constants::GENDER_MALE)
+                    ->addEmailAddress(1, Constants::CONTACT_DETAILS_TYPE_OFFICE, $email)
+                    ->create(),
+                'person',
+            ],
+            'companies create' => [
+                static fn (string $email): object => (new CompaniesCreateRequestBuilder())
+                    ->setCompany('ABC Company')
+                    ->addEmailAddress(Constants::CONTACT_DETAILS_TYPE_OFFICE, $email)
+                    ->create(),
+                'company',
+            ],
+            'companies update' => [
+                static fn (string $email): object => (new CompaniesUpdateRequestBuilder())
+                    ->setCompany('DEF company')
+                    ->addEmailAddress(1, Constants::CONTACT_DETAILS_TYPE_OFFICE, $email)
+                    ->create(),
+                'company',
+            ],
+        ];
+    }
+
+    /**
+     * A leading/trailing whitespace e-mail must be trimmed by every builder.
+     *
+     * @dataProvider builderProvider
+     *
+     * @param callable(string): object $buildRequest
+     * @param string                   $rootKey
+     *
+     * @test
+     *
+     * @throws RequestValidatorException
+     * @throws JsonException
+     */
+    public function addEmailAddressTrimsWhitespace(callable $buildRequest, string $rootKey): void
+    {
+        $this->assertAddedEmailIsTrimmed($buildRequest('  trimmed@example.org  '), $rootKey);
+    }
+}

--- a/test/RequestBuilder/RequestBuilderTestCase.php
+++ b/test/RequestBuilder/RequestBuilderTestCase.php
@@ -57,4 +57,24 @@ class RequestBuilderTestCase extends TestCase
 
         self::assertSame($expectedJson, $actualJson);
     }
+
+    /**
+     * Asserts the first e-mail address of the built request has been trimmed.
+     *
+     * @param object $request The built request
+     * @param string $rootKey The serialized root key ("person" or "company")
+     *
+     * @throws JsonException
+     */
+    protected function assertAddedEmailIsTrimmed(object $request, string $rootKey): void
+    {
+        $data = json_decode(
+            $this->serializer->encode($request),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertSame('trimmed@example.org', $data[$rootKey]['emails_attributes'][0]['name']);
+    }
 }


### PR DESCRIPTION
Trim the e-mail in addEmailAddress (People/Companies, create/update) so the stored value matches the trimmed lookup key and a whitespace e-mail never creates a duplicate. Adds a trim test per builder.