### PR TITLE
Allow symfony/http-client v7 in addition to v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^10.0",
         "rector/rector": "^2.0",
-        "symfony/http-client": "^6.0"
+        "symfony/http-client": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

Widens the `symfony/http-client` require-dev constraint from `^6.0` to `^6.0 || ^7.0`.

- **v6** (PHP >= 8.1) stays as the only line installable on PHP 8.1.
- **v7** (PHP >= 8.2) becomes available on the PHP 8.2/8.3 CI jobs.
- **v8** is intentionally excluded: it requires PHP >= 8.4, which is outside this SDK's supported range (`>=8.1 <8.4`).

Supersedes renovate PR #29, which bumped straight to `^8.0` and would have dropped v6, breaking installation on PHP 8.1/8.2/8.3.

## Verification

Full `composer ci:test` green on the PHP 8.1 buildbox:
- phplint, phpstan (level 8, no errors), rector (0 changes), php-cs-fixer (0 fixable)
- phpunit: 135 tests, 858 assertions OK
- `composer update symfony/http-client` resolves to v6.4.42 on PHP 8.1 as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)