### PR TITLE
Omit null-valued fields from serialized address requests

### DIFF
--- a/src/Request/Address.php
+++ b/src/Request/Address.php
@@ -161,19 +161,25 @@ class Address implements JsonSerializable
     }
 
     /**
-     * @return array<string, bool|int|string|null>
+     * @return array<string, bool|int|string>
      */
     public function jsonSerialize(): array
     {
-        return [
-            'id'           => $this->id,
-            'street'       => $this->street,
-            'zip'          => $this->zip,
-            'city'         => $this->city,
-            'state_code'   => $this->stateCode,
-            'country_code' => $this->countryCode,
-            'atype'        => $this->type,
-            'primary'      => $this->primary,
-        ];
+        // Omit null-valued fields so optional attributes (e.g. "state_code") are
+        // left out of the payload entirely instead of being sent as null, which
+        // the API rejects as invalid.
+        return array_filter(
+            [
+                'id'           => $this->id,
+                'street'       => $this->street,
+                'zip'          => $this->zip,
+                'city'         => $this->city,
+                'state_code'   => $this->stateCode,
+                'country_code' => $this->countryCode,
+                'atype'        => $this->type,
+                'primary'      => $this->primary,
+            ],
+            static fn (bool|int|string|null $value): bool => $value !== null
+        );
     }
 }

--- a/test/Request/Companies/Addresses/CreateTest.php
+++ b/test/Request/Companies/Addresses/CreateTest.php
@@ -47,11 +47,45 @@ class CreateTest extends TestCase
         self::assertSame(
             [
                 'addr' => [
-                    'id'           => null,
                     'street'       => 'Mustergasse 1',
                     'zip'          => '01234',
                     'city'         => 'Musterstadt',
                     'state_code'   => 'SN',
+                    'country_code' => 'DE',
+                    'atype'        => 'private',
+                    'primary'      => true,
+                ],
+            ],
+            $request->jsonSerialize()
+        );
+    }
+
+    /**
+     * Tests that null-valued fields are omitted from the serialized request, so
+     * the API is not sent e.g. "state_code": null (which it rejects as invalid).
+     *
+     * @test
+     */
+    public function jsonSerializeOmitsNullValues(): void
+    {
+        $address = new Address();
+        $address
+            ->setStreet('Mustergasse 1')
+            ->setZip('01234')
+            ->setCity('Musterstadt')
+            ->setCountryCode('DE')
+            ->setPrimary(true)
+            ->setType(Constants::ADDRESS_TYPE_PRIVATE);
+
+        // "id" (on create) and "stateCode" are intentionally left null.
+        $request = new Create($address);
+
+        self::assertSame(
+            [
+                'addr' => [
+                    'street'       => 'Mustergasse 1',
+                    'zip'          => '01234',
+                    'city'         => 'Musterstadt',
                     'country_code' => 'DE',
                     'atype'        => 'private',
                     'primary'      => true,

--- a/test/Request/Companies/Addresses/UpdateTest.php
+++ b/test/Request/Companies/Addresses/UpdateTest.php
@@ -48,11 +48,9 @@ class UpdateTest extends TestCase
         self::assertSame(
             [
                 'addr' => [
-                    'id'           => null,
                     'street'       => 'Mustergasse 2',
                     'zip'          => '98765',
                     'city'         => 'Musterhausen',
-                    'state_code'   => null,
                     'country_code' => 'AT',
                     'atype'        => 'work',
                     'primary'      => false,

--- a/test/Request/Companies/CreateTest.php
+++ b/test/Request/Companies/CreateTest.php
@@ -142,11 +142,8 @@ class CreateTest extends TestCase
                     'homepages_attributes' => null,
                     'addrs_attributes'     => [
                         [
-                            'id'           => null,
                             'street'       => 'Street 1',
-                            'zip'          => null,
                             'city'         => 'New York',
-                            'state_code'   => null,
                             'country_code' => 'US',
                             'atype'        => 'work_hq',
                             'primary'      => false,

--- a/test/Request/People/Addresses/CreateTest.php
+++ b/test/Request/People/Addresses/CreateTest.php
@@ -47,7 +47,6 @@ class CreateTest extends TestCase
         self::assertSame(
             [
                 'addr' => [
-                    'id'           => null,
                     'street'       => 'Mustergasse 1',
                     'zip'          => '01234',
                     'city'         => 'Musterstadt',

--- a/test/Request/People/Addresses/UpdateTest.php
+++ b/test/Request/People/Addresses/UpdateTest.php
@@ -48,11 +48,9 @@ class UpdateTest extends TestCase
         self::assertSame(
             [
                 'addr' => [
-                    'id'           => null,
                     'street'       => 'Mustergasse 2',
                     'zip'          => '98765',
                     'city'         => 'Musterhausen',
-                    'state_code'   => null,
                     'country_code' => 'AT',
                     'atype'        => 'work',
                     'primary'      => false,

--- a/test/Request/People/CreateTest.php
+++ b/test/Request/People/CreateTest.php
@@ -152,11 +152,8 @@ class CreateTest extends TestCase
                     'homepages_attributes' => null,
                     'addrs_attributes'     => [
                         [
-                            'id'           => null,
                             'street'       => 'Street 1',
-                            'zip'          => null,
                             'city'         => 'New York',
-                            'state_code'   => null,
                             'country_code' => 'US',
                             'atype'        => 'work_hq',
                             'primary'      => false,


### PR DESCRIPTION
## Problem

CentralStation rejects an address whose `state_code` is sent as `null` with **HTTP 422** (`{"addrs.state_code":["ist nicht gültig"]}`). Because `Request\Address::jsonSerialize()` always emitted every field, a consumer that does not set a state code sent `"state_code": null` and the whole company/person sync failed.

## Fix

Filter `null` values out of `Request\Address::jsonSerialize()` so optional attributes (e.g. `state_code`, and `id` on create) are omitted from the payload entirely instead of being sent as `null`. Non-null falsy values (`false`, `''`, `0`) are preserved, so clearing a field via an empty string still works.

## Tests

- New `CreateTest::jsonSerializeOmitsNullValues` asserting null fields are dropped.
- Updated existing address request expectations (id/zip/state_code null entries removed).
- Full CI chain green locally (phplint, phpstan, rector, phpunit, php-cs-fixer).