### PR TITLE
ci: migrate to org php-ci shared reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,81 +1,26 @@
 name: CI
 
 on:
-    push:
-    pull_request:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [ '8.1', '8.2', '8.3' ]
-
-        steps:
-            -   id: checkout
-                name: Checkout
-                uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-            -   id: setup_php
-                name: Set up PHP version ${{ matrix.php }}
-                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
-                with:
-                    php-version: ${{ matrix.php }}
-                    tools: composer:v2, php-cs-fixer
-
-            -   name: Validate composer.json and composer.lock
-                run: composer validate
-
-            -   id: composer-cache-vars
-                name: Composer Cache Vars
-                run: |
-                    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-                    echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
-
-            -   id: composer-cache-dependencies
-                name: Cache Composer dependencies
-                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-                with:
-                    path: ${{ steps.composer-cache-vars.outputs.dir }}
-                    key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ steps.composer-cache-vars.outputs.timestamp }}
-                    restore-keys: |
-                        ${{ runner.os }}-composer-${{ matrix.php }}-
-                        ${{ runner.os }}-composer-
-
-            -   id: install
-                name: Install dependencies
-                run: |
-                    composer validate
-                    composer install --no-progress
-
-            -   id: lint
-                name: Lint
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:test:php:lint
-
-            -   id: cgl
-                name: CGL
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:cgl -- --dry-run
-
-            -   id: phpstan
-                name: PHPStan
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:test:php:phpstan -- --error-format=github
-
-            -   id: rector
-                name: Rector
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:test:php:rector
-
-            -   id: tests_unit
-                name: Unit Tests
-                if: ${{ always() && steps.install.conclusion == 'success' }}
-                run: |
-                    composer ci:test:php:unit
+  php-ci:
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    with:
+      php-versions: '["8.1","8.2","8.3"]'
+      # Reusable's composer-validate runs `--strict`, which fails on this
+      # library's intentional unbound `*` constraints for the virtual PSR
+      # implementation packages. Keep the non-strict `composer validate`
+      # the previous workflow used by running it via pre-install-cmd.
+      composer-validate: false
+      pre-install-cmd: "composer validate"
+      phpstan-cmd: "composer ci:test:php:phpstan -- --error-format=github"
+      phpunit-cmd: "composer ci:test:php:unit"
+      run-cs-fixer: true
+      cs-fixer-cmd: "composer ci:test:php:cgl"
+      run-rector: true
+      rector-cmd: "composer ci:test:php:rector"


### PR DESCRIPTION
## What
Migrate CI to the org-owned **`netresearch/.github` `php-ci.yml@main`** reusable — the repo had a fully inline workflow (checkout + `shivammathur/setup-php` + `actions/cache` + composer + phpunit/phpstan/cs-fixer). It now calls the central reusable, so third-party actions live only there (easier maintenance).

Inputs mirror the repo's existing PHP-version matrix and composer scripts. `@main` is intentional (NR-owned reusable — never SHA-pinned).

## Verification
`actionlint` clean; every `with:`/`secrets:` value is a declared `php-ci.yml` input/secret.

## Behavior notes
- `composer-validate: false` + `pre-install-cmd: "composer validate"` (non-strict) — the reusable's default `--strict` fails on this library's intentional unbound `*` constraints for virtual PSR packages.
- The standalone `phplint` gate has no reusable slot; PHPStan still parses every file so syntax errors are caught. Follow-up: add a `run-lint`/`lint-cmd` input to `php-ci.yml`.
